### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -23,7 +23,7 @@ class AmalgamationFile:
         def add_marker(prefix):
             self.add_text("")
             self.add_text("// " + "/"*70)
-            self.add_text("// %s of content of file: %s" % (prefix, relative_input_path.replace("\\","/")))
+            self.add_text("// {0!s} of content of file: {1!s}".format(prefix, relative_input_path.replace("\\","/")))
             self.add_text("// " + "/"*70)
             self.add_text("")
         add_marker("Beginning")
@@ -59,7 +59,7 @@ def amalgamate_source(source_top_dir=None,
     print("Amalgating header...")
     header = AmalgamationFile(source_top_dir)
     header.add_text("/// Json-cpp amalgated header (http://jsoncpp.sourceforge.net/).")
-    header.add_text('/// It is intended to be used with #include "%s"' % header_include_path)
+    header.add_text('/// It is intended to be used with #include "{0!s}"'.format(header_include_path))
     header.add_file("LICENSE", wrap_in_comment=True)
     header.add_text("#ifndef JSON_AMALGATED_H_INCLUDED")
     header.add_text("# define JSON_AMALGATED_H_INCLUDED")
@@ -77,7 +77,7 @@ def amalgamate_source(source_top_dir=None,
     header.add_text("#endif //ifndef JSON_AMALGATED_H_INCLUDED")
 
     target_header_path = os.path.join(os.path.dirname(target_source_path), header_include_path)
-    print("Writing amalgated header to %r" % target_header_path)
+    print("Writing amalgated header to {0!r}".format(target_header_path))
     header.write_to(target_header_path)
 
     base, ext = os.path.splitext(header_include_path)
@@ -85,7 +85,7 @@ def amalgamate_source(source_top_dir=None,
     print("Amalgating forward header...")
     header = AmalgamationFile(source_top_dir)
     header.add_text("/// Json-cpp amalgated forward header (http://jsoncpp.sourceforge.net/).")
-    header.add_text('/// It is intended to be used with #include "%s"' % forward_header_include_path)
+    header.add_text('/// It is intended to be used with #include "{0!s}"'.format(forward_header_include_path))
     header.add_text("/// This header provides forward declaration for all JsonCpp types.")
     header.add_file("LICENSE", wrap_in_comment=True)
     header.add_text("#ifndef JSON_FORWARD_AMALGATED_H_INCLUDED")
@@ -99,16 +99,16 @@ def amalgamate_source(source_top_dir=None,
 
     target_forward_header_path = os.path.join(os.path.dirname(target_source_path),
                                                forward_header_include_path)
-    print("Writing amalgated forward header to %r" % target_forward_header_path)
+    print("Writing amalgated forward header to {0!r}".format(target_forward_header_path))
     header.write_to(target_forward_header_path)
 
     print("Amalgating source...")
     source = AmalgamationFile(source_top_dir)
     source.add_text("/// Json-cpp amalgated source (http://jsoncpp.sourceforge.net/).")
-    source.add_text('/// It is intended to be used with #include "%s"' % header_include_path)
+    source.add_text('/// It is intended to be used with #include "{0!s}"'.format(header_include_path))
     source.add_file("LICENSE", wrap_in_comment=True)
     source.add_text("")
-    source.add_text('#include "%s"' % header_include_path)
+    source.add_text('#include "{0!s}"'.format(header_include_path))
     source.add_text("""
 #ifndef JSON_IS_AMALGAMATION
 #error "Compile with -I PATH_TO_JSON_DIRECTORY"
@@ -122,7 +122,7 @@ def amalgamate_source(source_top_dir=None,
     source.add_file(os.path.join(lib_json, "json_value.cpp"))
     source.add_file(os.path.join(lib_json, "json_writer.cpp"))
 
-    print("Writing amalgated source to %r" % target_source_path)
+    print("Writing amalgated source to {0!r}".format(target_source_path))
     source.write_to(target_source_path)
 
 def main():

--- a/devtools/antglob.py
+++ b/devtools/antglob.py
@@ -68,7 +68,7 @@ def ant_pattern_to_re(ant_pattern):
     """
     rex = ['^']
     next_pos = 0
-    sep_rex = r'(?:/|%s)' % re.escape(os.path.sep)
+    sep_rex = r'(?:/|{0!s})'.format(re.escape(os.path.sep))
 ##    print 'Converting', ant_pattern
     for match in _ANT_RE.finditer(ant_pattern):
 ##        print 'Matched', match.group()
@@ -76,13 +76,13 @@ def ant_pattern_to_re(ant_pattern):
         if match.start(0) != next_pos:
             raise ValueError("Invalid ant pattern")
         if match.group(1): # /**/
-            rex.append(sep_rex + '(?:.*%s)?' % sep_rex)
+            rex.append(sep_rex + '(?:.*{0!s})?'.format(sep_rex))
         elif match.group(2): # **/
-            rex.append('(?:.*%s)?' % sep_rex)
+            rex.append('(?:.*{0!s})?'.format(sep_rex))
         elif match.group(3): # /**
             rex.append(sep_rex + '.*')
         elif match.group(4): # *
-            rex.append('[^/%s]*' % re.escape(os.path.sep))
+            rex.append('[^/{0!s}]*'.format(re.escape(os.path.sep)))
         elif match.group(5): # /
             rex.append(sep_rex)
         else: # somepath

--- a/devtools/batchbuild.py
+++ b/devtools/batchbuild.py
@@ -41,16 +41,16 @@ class BuildDesc:
         return environ
 
     def cmake_args(self):
-        args = ["-D%s" % var for var in self.variables]
+        args = ["-D{0!s}".format(var) for var in self.variables]
         # skip build type for Visual Studio solution as it cause warning
         if self.build_type and 'Visual' not in self.generator:
-            args.append("-DCMAKE_BUILD_TYPE=%s" % self.build_type)
+            args.append("-DCMAKE_BUILD_TYPE={0!s}".format(self.build_type))
         if self.generator:
             args.extend(['-G', self.generator])
         return args
 
     def __repr__(self):
-        return "BuildDesc(%s, build_type=%s)" %  (" ".join(self.cmake_args()), self.build_type)
+        return "BuildDesc({0!s}, build_type={1!s})".format(" ".join(self.cmake_args()), self.build_type)
 
 class BuildData:
     def __init__(self, desc, work_dir, source_dir):
@@ -63,7 +63,7 @@ class BuildData:
         self.build_succeeded = False
 
     def execute_build(self):
-        print('Build %s' % self.desc)
+        print('Build {0!s}'.format(self.desc))
         self._make_new_work_dir()
         self.cmake_succeeded = self._generate_makefiles()
         if self.cmake_succeeded:
@@ -92,7 +92,7 @@ class BuildData:
         stdout, _ = process.communicate()
         succeeded = (process.returncode == 0)
         with open(log_path, 'wb') as flog:
-            log = ' '.join(cmd) + '\n' + stdout + '\nExit code: %r\n' % process.returncode
+            log = ' '.join(cmd) + '\n' + stdout + '\nExit code: {0!r}\n'.format(process.returncode)
             flog.write(fix_eol(log))
         return succeeded
 
@@ -195,12 +195,12 @@ def generate_html_report(html_report_path, builds):
     for variable in variables:
         build_types = sorted(build_types_by_variable[variable])
         nb_build_type = len(build_types_by_variable[variable])
-        th_vars.append('<th colspan="%d">%s</th>' % (nb_build_type, cgi.escape(' '.join(variable))))
+        th_vars.append('<th colspan="{0:d}">{1!s}</th>'.format(nb_build_type, cgi.escape(' '.join(variable))))
         for build_type in build_types:
-            th_build_types.append('<th>%s</th>' % cgi.escape(build_type))
+            th_build_types.append('<th>{0!s}</th>'.format(cgi.escape(build_type)))
     tr_builds = []
     for generator in sorted(builds_by_generator):
-        tds = [ '<td>%s</td>\n' % cgi.escape(generator) ]
+        tds = [ '<td>{0!s}</td>\n'.format(cgi.escape(generator)) ]
         for variable in variables:
             build_types = sorted(build_types_by_variable[variable])
             for build_type in build_types:
@@ -211,14 +211,14 @@ def generate_html_report(html_report_path, builds):
                     build_status = 'ok' if build.build_succeeded else 'FAILED'
                     cmake_log_url = os.path.relpath(build.cmake_log_path, report_dir)
                     build_log_url = os.path.relpath(build.build_log_path, report_dir)
-                    td = '<td class="%s"><a href="%s" class="%s">CMake: %s</a>' % (                        build_status.lower(), cmake_log_url, cmake_status.lower(), cmake_status)
+                    td = '<td class="{0!s}"><a href="{1!s}" class="{2!s}">CMake: {3!s}</a>'.format(build_status.lower(), cmake_log_url, cmake_status.lower(), cmake_status)
                     if build.cmake_succeeded:
-                        td += '<br><a href="%s" class="%s">Build: %s</a>' % (                            build_log_url, build_status.lower(), build_status)
+                        td += '<br><a href="{0!s}" class="{1!s}">Build: {2!s}</a>'.format(build_log_url, build_status.lower(), build_status)
                     td += '</td>'
                 else:
                     td = '<td></td>'
                 tds.append(td)
-        tr_builds.append('<tr>%s</tr>' % '\n'.join(tds))
+        tr_builds.append('<tr>{0!s}</tr>'.format('\n'.join(tds)))
     html = HTML_TEMPLATE.substitute(        title='Batch build report',
         th_vars=' '.join(th_vars),
         th_build_types=' '.join(th_build_types),
@@ -249,23 +249,23 @@ python devtools\batchbuild.py e:\buildbots\jsoncpp\build . devtools\agent_vmw7.j
     config_paths = args[2:]
     for config_path in config_paths:
         if not os.path.isfile(config_path):
-            parser.error("Can not read: %r" % config_path)
+            parser.error("Can not read: {0!r}".format(config_path))
 
     # generate build variants
     build_descs = []
     for config_path in config_paths:
         build_descs_by_axis = load_build_variants_from_config(config_path)
         build_descs.extend(generate_build_variants(build_descs_by_axis))
-    print('Build variants (%d):' % len(build_descs))
+    print('Build variants ({0:d}):'.format(len(build_descs)))
     # assign build directory for each variant
     if not os.path.isdir(work_dir):
         os.makedirs(work_dir)
     builds = []
     with open(os.path.join(work_dir, 'matrix-dir-map.txt'), 'wt') as fmatrixmap:
         for index, build_desc in enumerate(build_descs):
-            build_desc_work_dir = os.path.join(work_dir, '%03d' % (index+1))
+            build_desc_work_dir = os.path.join(work_dir, '{0:03d}'.format((index+1)))
             builds.append(BuildData(build_desc, build_desc_work_dir, source_dir))
-            fmatrixmap.write('%s: %s\n' % (build_desc_work_dir, build_desc))
+            fmatrixmap.write('{0!s}: {1!s}\n'.format(build_desc_work_dir, build_desc))
     for build in builds:
         build.execute_build()
     html_report_path = os.path.join(work_dir, 'batchbuild-report.html')

--- a/devtools/fixeol.py
+++ b/devtools/fixeol.py
@@ -10,11 +10,11 @@ import sys
 def fix_source_eol(path, is_dry_run = True, verbose = True, eol = '\n'):
     """Makes sure that all sources have the specified eol sequence (default: unix)."""
     if not os.path.isfile(path):
-        raise ValueError('Path "%s" is not a file' % path)
+        raise ValueError('Path "{0!s}" is not a file'.format(path))
     try:
         f = open(path, 'rb')
     except IOError as msg:
-        print("%s: I/O Error: %s" % (file, str(msg)), file=sys.stderr)
+        print("{0!s}: I/O Error: {1!s}".format(file, str(msg)), file=sys.stderr)
         return False
     try:
         raw_lines = f.readlines()
@@ -22,7 +22,7 @@ def fix_source_eol(path, is_dry_run = True, verbose = True, eol = '\n'):
         f.close()
     fixed_lines = [line.rstrip('\r\n') + eol for line in raw_lines]
     if raw_lines != fixed_lines:
-        print('%s =>' % path, end=' ')
+        print('{0!s} =>'.format(path), end=' ')
         if not is_dry_run:
             f = open(path, "wb")
             try:

--- a/doxybuild.py
+++ b/doxybuild.py
@@ -66,7 +66,7 @@ def getstatusoutput(cmd):
 def run_cmd(cmd, silent=False):
     """Raise exception on failure.
     """
-    info = 'Running: %r in %r' %(' '.join(cmd), os.getcwd())
+    info = 'Running: {0!r} in {1!r}'.format(' '.join(cmd), os.getcwd())
     print(info)
     sys.stdout.flush()
     if silent:
@@ -74,16 +74,16 @@ def run_cmd(cmd, silent=False):
     else:
         status, output = subprocess.call(cmd), ''
     if status:
-        msg = 'Error while %s ...\n\terror=%d, output="""%s"""' %(info, status, output)
+        msg = 'Error while {0!s} ...\n\terror={1:d}, output="""{2!s}"""'.format(info, status, output)
         raise Exception(msg)
 
 def assert_is_exe(path):
     if not path:
         raise Exception('path is empty.')
     if not os.path.isfile(path):
-        raise Exception('%r is not a file.' %path)
+        raise Exception('{0!r} is not a file.'.format(path))
     if not os.access(path, os.X_OK):
-        raise Exception('%r is not executable by this user.' %path)
+        raise Exception('{0!r} is not executable by this user.'.format(path))
 
 def run_doxygen(doxygen_path, config_file, working_dir, is_silent):
     assert_is_exe(doxygen_path)

--- a/makerelease.py
+++ b/makerelease.py
@@ -73,7 +73,7 @@ def check_no_pending_commit():
         path = entry.get('path')
         status = entry.find('wc-status').get('item')
         if status != 'unversioned' and path != 'version':
-            msg.append('File "%s" has pending change (status="%s")' % (path, status))
+            msg.append('File "{0!s}" has pending change (status="{1!s}")'.format(path, status))
     if msg:
         msg.insert(0, 'Pending change to commit found in sandbox. Commit them first!')
     return '\n'.join(msg)
@@ -154,9 +154,9 @@ def download(url, target_path):
         fout.close()
 
 def check_compile(distcheck_top_dir, platform):
-    cmd = [sys.executable, 'scons.py', 'platform=%s' % platform, 'check']
+    cmd = [sys.executable, 'scons.py', 'platform={0!s}'.format(platform), 'check']
     print('Running:', ' '.join(cmd))
-    log_path = os.path.join(distcheck_top_dir, 'build-%s.log' % platform)
+    log_path = os.path.join(distcheck_top_dir, 'build-{0!s}.log'.format(platform))
     flog = open(log_path, 'wb')
     try:
         process = subprocess.Popen(cmd,
@@ -203,7 +203,7 @@ def sourceforge_web_synchro(sourceforge_project, doc_dir,
                              user=None, sftp='sftp'):
     """Notes: does not synchronize sub-directory of doc-dir.
     """
-    userhost = '%s,%s@web.sourceforge.net' % (user, sourceforge_project)
+    userhost = '{0!s},{1!s}@web.sourceforge.net'.format(user, sourceforge_project)
     stdout = run_sftp_batch(userhost, sftp, """
 cd htdocs
 dir
@@ -229,9 +229,9 @@ exit
         print('Removing the following file from web:')
         print('\n'.join(paths_to_remove))
         stdout = run_sftp_batch(userhost, sftp, """cd htdocs
-rm %s
-exit""" % ' '.join(paths_to_remove))
-    print('Uploading %d files:' % len(upload_paths))
+rm {0!s}
+exit""".format(' '.join(paths_to_remove)))
+    print('Uploading {0:d} files:'.format(len(upload_paths)))
     batch_size = 10
     upload_paths = list(upload_paths)
     start_time = time.time()
@@ -240,18 +240,18 @@ exit""" % ' '.join(paths_to_remove))
         file_per_sec = (time.time() - start_time) / (index+1)
         remaining_files = len(upload_paths) - index
         remaining_sec = file_per_sec * remaining_files
-        print('%d/%d, ETA=%.1fs' % (index+1, len(upload_paths), remaining_sec))
+        print('{0:d}/{1:d}, ETA={2:.1f}s'.format(index+1, len(upload_paths), remaining_sec))
         run_sftp_batch(userhost, sftp, """cd htdocs
-lcd %s
-mput %s
-exit""" % (doc_dir, ' '.join(paths)), retry=3)
+lcd {0!s}
+mput {1!s}
+exit""".format(doc_dir, ' '.join(paths)), retry=3)
 
 def sourceforge_release_tarball(sourceforge_project, paths, user=None, sftp='sftp'):
-    userhost = '%s,%s@frs.sourceforge.net' % (user, sourceforge_project)
+    userhost = '{0!s},{1!s}@frs.sourceforge.net'.format(user, sourceforge_project)
     run_sftp_batch(userhost, sftp, """
-mput %s
+mput {0!s}
 exit
-""" % (' '.join(paths),))
+""".format(' '.join(paths)))
 
 
 def main():
@@ -312,7 +312,7 @@ Warning: --force should only be used when developping/testing the release script
             if options.retag_release:
                 svn_remove_tag(tag_url, 'Overwriting previous tag')
             else:
-                print('Aborting, tag %s already exist. Use --retag to overwrite it!' % tag_url)
+                print('Aborting, tag {0!s} already exist. Use --retag to overwrite it!'.format(tag_url))
                 sys.exit(1)
         svn_tag_sandbox(tag_url, 'Release ' + release_version)
 
@@ -329,14 +329,14 @@ Warning: --force should only be used when developping/testing the release script
         fix_sources_eol(export_dir)
         
         source_dir = 'jsoncpp-src-' + release_version
-        source_tarball_path = 'dist/%s.tar.gz' % source_dir
+        source_tarball_path = 'dist/{0!s}.tar.gz'.format(source_dir)
         print('Generating source tarball to', source_tarball_path)
         tarball.make_tarball(source_tarball_path, [export_dir], export_dir, prefix_dir=source_dir)
 
-        amalgamation_tarball_path = 'dist/%s-amalgamation.tar.gz' % source_dir
+        amalgamation_tarball_path = 'dist/{0!s}-amalgamation.tar.gz'.format(source_dir)
         print('Generating amalgamation source tarball to', amalgamation_tarball_path)
         amalgamation_dir = 'dist/amalgamation'
-        amalgamate.amalgamate_source(export_dir, '%s/jsoncpp.cpp' % amalgamation_dir, 'json/json.h')
+        amalgamate.amalgamate_source(export_dir, '{0!s}/jsoncpp.cpp'.format(amalgamation_dir), 'json/json.h')
         amalgamation_source_dir = 'jsoncpp-src-amalgamation' + release_version
         tarball.make_tarball(amalgamation_tarball_path, [amalgamation_dir],
                               amalgamation_dir, prefix_dir=amalgamation_source_dir)

--- a/scons-tools/substinfile.py
+++ b/scons-tools/substinfile.py
@@ -31,7 +31,7 @@ def generate(env):
             contents = f.read()
             f.close()
         except:
-            raise SCons.Errors.UserError("Can't read source file %s"%sourcefile)
+            raise SCons.Errors.UserError("Can't read source file {0!s}".format(sourcefile))
         for (k,v) in list(dict.items()):
             contents = re.sub(k, v, contents)
         try:
@@ -39,7 +39,7 @@ def generate(env):
             f.write(contents)
             f.close()
         except:
-            raise SCons.Errors.UserError("Can't write target file %s"%targetfile)
+            raise SCons.Errors.UserError("Can't write target file {0!s}".format(targetfile))
         return 0 # success
 
     def subst_in_file(target, source, env):
@@ -52,13 +52,13 @@ def generate(env):
             elif SCons.Util.is_String(v):
                 d[k] = env.subst(v).replace('\\','\\\\')
             else:
-                raise SCons.Errors.UserError("SubstInFile: key %s: %s must be a string or callable"%(k, repr(v)))
+                raise SCons.Errors.UserError("SubstInFile: key {0!s}: {1!s} must be a string or callable".format(k, repr(v)))
         for (t,s) in zip(target, source):
             return do_subst_in_file(str(t), str(s), d)
 
     def subst_in_file_string(target, source, env):
         """This is what gets printed on the console."""
-        return '\n'.join(['Substituting vars from %s into %s'%(str(s), str(t))
+        return '\n'.join(['Substituting vars from {0!s} into {1!s}'.format(str(s), str(t))
                           for (t,s) in zip(target, source)])
 
     def subst_emitter(target, source, env):

--- a/test/pyjsontestrunner.py
+++ b/test/pyjsontestrunner.py
@@ -25,28 +25,28 @@ rewrite_actual_path = base_path + '.actual-rewrite'
 def valueTreeToString(fout, value, path = '.'):
     ty = type(value) 
     if ty  is types.DictType:
-        fout.write('%s={}\n' % path)
+        fout.write('{0!s}={{}}\n'.format(path))
         suffix = path[-1] != '.' and '.' or ''
         names = value.keys()
         names.sort()
         for name in names:
             valueTreeToString(fout, value[name], path + suffix + name)
     elif ty is types.ListType:
-        fout.write('%s=[]\n' % path)
+        fout.write('{0!s}=[]\n'.format(path))
         for index, childValue in zip(xrange(0,len(value)), value):
-            valueTreeToString(fout, childValue, path + '[%d]' % index)
+            valueTreeToString(fout, childValue, path + '[{0:d}]'.format(index))
     elif ty is types.StringType:
-        fout.write('%s="%s"\n' % (path,value))
+        fout.write('{0!s}="{1!s}"\n'.format(path, value))
     elif ty is types.IntType:
-        fout.write('%s=%d\n' % (path,value))
+        fout.write('{0!s}={1:d}\n'.format(path, value))
     elif ty is types.FloatType:
-        fout.write('%s=%.16g\n' % (path,value))
+        fout.write('{0!s}={1:.16g}\n'.format(path, value))
     elif value is True:
-        fout.write('%s=true\n' % path)
+        fout.write('{0!s}=true\n'.format(path))
     elif value is False:
-        fout.write('%s=false\n' % path)
+        fout.write('{0!s}=false\n'.format(path))
     elif value is None:
-        fout.write('%s=null\n' % path)
+        fout.write('{0!s}=null\n'.format(path))
     else:
         assert False and "Unexpected value type"
         

--- a/test/runjsontests.py
+++ b/test/runjsontests.py
@@ -49,10 +49,10 @@ def compareOutputs(expected, actual, message):
         if index >= len(lines):
             return ''
         return lines[index].strip()
-    return """  Difference in %s at line %d:
-  Expected: '%s'
-  Actual:   '%s'
-""" % (message, diff_line,
+    return """  Difference in {0!s} at line {1:d}:
+  Expected: '{2!s}'
+  Actual:   '{3!s}'
+""".format(message, diff_line,
        safeGetLine(expected,diff_line),
        safeGetLine(actual,diff_line))
         
@@ -60,7 +60,7 @@ def safeReadFile(path):
     try:
         return open(path, 'rt', encoding = 'utf-8').read()
     except IOError as e:
-        return '<File "%s" is missing: %s>' % (path,e)
+        return '<File "{0!s}" is missing: {1!s}>'.format(path, e)
 
 def runAllTests(jsontest_executable_path, input_dir = None,
                  use_valgrind=False, with_json_checker=False,
@@ -79,16 +79,16 @@ def runAllTests(jsontest_executable_path, input_dir = None,
         is_json_checker_test = (input_path in test_jsonchecker) or expect_failure
         print('TESTING:', input_path, end=' ')
         options = is_json_checker_test and '--json-checker' or ''
-        options += ' --json-writer %s'%writerClass
-        cmd = '%s%s %s "%s"' % (            valgrind_path, jsontest_executable_path, options,
+        options += ' --json-writer {0!s}'.format(writerClass)
+        cmd = '{0!s}{1!s} {2!s} "{3!s}"'.format(valgrind_path, jsontest_executable_path, options,
             input_path)
         status, process_output = getStatusOutput(cmd)
         if is_json_checker_test:
             if expect_failure:
                 if not status:
                     print('FAILED')
-                    failed_tests.append((input_path, 'Parsing should have failed:\n%s' %
-                                          safeReadFile(input_path)))
+                    failed_tests.append((input_path, 'Parsing should have failed:\n{0!s}'.format(
+                                          safeReadFile(input_path))))
                 else:
                     print('OK')
             else:
@@ -123,11 +123,11 @@ def runAllTests(jsontest_executable_path, input_dir = None,
             print('* Test', failed_test[0])
             print(failed_test[1])
             print()
-        print('Test results: %d passed, %d failed.' % (len(tests)-len(failed_tests),
+        print('Test results: {0:d} passed, {1:d} failed.'.format(len(tests)-len(failed_tests),
                                                        len(failed_tests)))
         return 1
     else:
-        print('All %d tests passed.' % len(tests))
+        print('All {0:d} tests passed.'.format(len(tests)))
         return 0
 
 def main():

--- a/test/rununittests.py
+++ b/test/rununittests.py
@@ -45,7 +45,7 @@ def runAllTests(exe_path, use_valgrind=False):
     test_names = [name.strip() for name in test_names.decode('utf-8').strip().split('\n')]
     failures = []
     for name in test_names:
-        print('TESTING %s:' % name, end=' ')
+        print('TESTING {0!s}:'.format(name), end=' ')
         succeed, result = test_proxy.run(['--test', name])
         if succeed:
             print('OK')
@@ -58,10 +58,10 @@ def runAllTests(exe_path, use_valgrind=False):
         print()
         for name, result in failures:
             print(result)
-        print('%d/%d tests passed (%d failure(s))' % (            pass_count, len(test_names), failed_count))
+        print('{0:d}/{1:d} tests passed ({2:d} failure(s))'.format(pass_count, len(test_names), failed_count))
         return 1
     else:
-        print('All %d tests passed' % len(test_names))
+        print('All {0:d} tests passed'.format(len(test_names)))
         return 0
 
 def main():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:jsoncpp?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:jsoncpp?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
